### PR TITLE
feat: apply aquadrop premium theme

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,210 +1,176 @@
-// Types
-type Feature = {
-  title: string;
+import Hero from './components/Hero';
+import ProductCard from './components/ProductCard';
+
+type Product = {
+  name: string;
   description: string;
+  price: string;
+  badgeLabel: string;
+  badgeTone: 'teal' | 'olive' | 'sand';
+  options: string[];
 };
 
-// Données
-const features: Feature[] = [
+const products: Product[] = [
   {
-    title: 'Formule éco-responsable',
+    name: 'Coffret Sport Vitalité',
     description:
-      'Nos pastilles concentrées réduisent drastiquement l’utilisation de plastique et offrent une mousse riche qui respecte votre peau.',
+      'Pastilles vivifiantes eucalyptus + flacon mousseur graphite. Pensé pour accompagner les routines sportives sans compromis sur la douceur.',
+    price: '24,90 €',
+    badgeLabel: 'Sport',
+    badgeTone: 'teal',
+    options: ['Recharge x3', 'Recharge x6', 'Starter pack'],
   },
   {
-    title: 'Utilisation simplifiée',
+    name: 'Essentiel Eco Pureté',
     description:
-      'Ajoutez simplement de l’eau, insérez une pastille et profitez instantanément d’un savon moussant doux et efficace.',
+      'Un rituel quotidien neutre pour les peaux sensibles : mousse généreuse, parfum discret et flacon durable fabriqué en Europe.',
+    price: '22,90 €',
+    badgeLabel: 'Eco',
+    badgeTone: 'olive',
+    options: ['Recharge x3', 'Recharge x9', 'Abonnement mensuel'],
   },
   {
-    title: 'Fraîcheur longue durée',
+    name: 'Collection Sans Fragrance',
     description:
-      'Chaque parfum est élaboré pour accompagner votre routine quotidienne avec une sensation de propreté durable.',
+      'Pastilles hypoallergéniques et flacon sablé : l’allié minimaliste des intérieurs épurés et des mains exigeantes.',
+    price: '21,50 €',
+    badgeLabel: 'Sans Fragrance',
+    badgeTone: 'sand',
+    options: ['Recharge x3', 'Recharge x6', 'Recharge x12'],
   },
 ];
 
-// Logo (SVG inline)
-const Logo = () => (
-  <svg
-    className="w-28 text-emerald-300 sm:w-36"
-    viewBox="0 0 140 140"
-    fill="none"
-    xmlns="http://www.w3.org/2000/svg"
-    role="img"
-    aria-labelledby="logoTitle logoDesc"
-  >
-    <title id="logoTitle">Logo AquaDrop</title>
-    <desc id="logoDesc">Une goutte d’eau contenant une pastille pétillante</desc>
-    <defs>
-      <linearGradient id="drop" x1="70" y1="0" x2="70" y2="140" gradientUnits="userSpaceOnUse">
-        <stop offset="0%" stopColor="#9AF6E3" />
-        <stop offset="100%" stopColor="#34D399" />
-      </linearGradient>
-      <radialGradient
-        id="tablet"
-        cx="0"
-        cy="0"
-        r="1"
-        gradientTransform="translate(70 85) scale(28)"
-        gradientUnits="userSpaceOnUse"
-      >
-        <stop offset="0%" stopColor="#F9FAFB" stopOpacity="0.95" />
-        <stop offset="100%" stopColor="#D1FAE5" stopOpacity="0.3" />
-      </radialGradient>
-    </defs>
-    <path
-      d="M70 10C70 10 22 66 22 96C22 120.301 43.699 138 68 138C92.301 138 114 120.301 114 96C114 66 70 10 70 10Z"
-      fill="url(#drop)"
-    />
-    <circle cx="70" cy="85" r="26" fill="url(#tablet)" />
-    <circle cx="70" cy="85" r="14" fill="#ECFEFF" opacity="0.9" />
-    <circle cx="70" cy="85" r="6" fill="#10B981" opacity="0.8" />
-    <path
-      d="M70 34C70 34 44 66 44 90C44 109.882 58.118 124 78 124"
-      stroke="#047857"
-      strokeWidth="4"
-      strokeLinecap="round"
-      opacity="0.35"
-    />
-  </svg>
-);
-
-// Bottle doit être défini AVANT ProductIllustration
-type BottleProps = {
-  x: number;
-  tone: string;
-  accent: string;
-};
-
-const Bottle = ({ x, tone, accent }: BottleProps) => (
-  <g transform={`translate(${x - 80} 80)`}>
-    <rect x="60" y="16" width="40" height="28" rx="8" fill={accent} opacity="0.65" />
-    <path d="M76 44h8v24h-8z" fill={accent} opacity="0.35" />
-    <rect x="52" y="64" width="56" height="210" rx="28" fill={tone} />
-    <rect x="52" y="64" width="56" height="210" rx="28" fill="#FFFFFF" fillOpacity="0.16" />
-    <rect x="60" y="104" width="40" height="104" rx="20" fill={accent} fillOpacity="0.35" />
-    <rect x="68" y="128" width="24" height="52" rx="12" fill={accent} fillOpacity="0.6" />
-    <path d="M56 272h48c0 16-12 28-24 28s-24-12-24-28z" fill="#0F172A" fillOpacity="0.45" />
-    <circle cx="80" cy="214" r="6" fill="#F8FAFC" opacity="0.6" />
-    <circle cx="96" cy="146" r="4" fill="#F8FAFC" opacity="0.5" />
-    <circle cx="72" cy="176" r="3" fill="#F8FAFC" opacity="0.35" />
-  </g>
-);
-
-// Illustration produit (utilise Bottle)
-const ProductIllustration = () => (
-  <svg
-    className="w-full max-w-xl"
-    viewBox="0 0 520 420"
-    fill="none"
-    xmlns="http://www.w3.org/2000/svg"
-    role="img"
-    aria-labelledby="productTitle productDesc"
-  >
-    <title id="productTitle">Présentation du produit AquaDrop</title>
-    <desc id="productDesc">Trois flacons de savon moussant avec des bulles et des reflets lumineux</desc>
-    <rect x="20" y="30" width="480" height="360" rx="36" fill="url(#bg)" />
-    <g filter="url(#glow)">
-      <circle cx="120" cy="140" r="42" fill="#6EE7B7" fillOpacity="0.5" />
-      <circle cx="400" cy="110" r="48" fill="#99F6E4" fillOpacity="0.45" />
-      <circle cx="300" cy="320" r="60" fill="#5EEAD4" fillOpacity="0.35" />
-    </g>
-    <g filter="url(#shadow)">
-      <ellipse cx="160" cy="320" rx="72" ry="22" fill="#064E3B" fillOpacity="0.45" />
-      <ellipse cx="260" cy="340" rx="80" ry="24" fill="#064E3B" fillOpacity="0.38" />
-      <ellipse cx="360" cy="320" rx="72" ry="22" fill="#064E3B" fillOpacity="0.45" />
-    </g>
-    <Bottle x={120} tone="#F0FDFA" accent="#34D399" />
-    <Bottle x={260} tone="#ECFEFF" accent="#14B8A6" />
-    <Bottle x={400} tone="#FEFCE8" accent="#FACC15" />
-    <defs>
-      <linearGradient id="bg" x1="20" y1="30" x2="500" y2="390" gradientUnits="userSpaceOnUse">
-        <stop offset="0%" stopColor="#022C22" />
-        <stop offset="100%" stopColor="#064E3B" />
-      </linearGradient>
-      <filter id="shadow" x="60" y="278" width="400" height="120" filterUnits="userSpaceOnUse" colorInterpolationFilters="sRGB">
-        <feGaussianBlur stdDeviation="12" result="blur" />
-      </filter>
-      <filter id="glow" x="40" y="40" width="440" height="320" filterUnits="userSpaceOnUse" colorInterpolationFilters="sRGB">
-        <feGaussianBlur stdDeviation="24" result="blur" />
-      </filter>
-    </defs>
-  </svg>
-);
-
-// App
 function App() {
   return (
-    <div className="min-h-screen bg-[#0f1c17] text-white">
-      <header className="flex flex-col items-center gap-4 px-6 pt-12 pb-10 text-center">
-        <Logo />
-        <div>
-          <p className="uppercase tracking-[0.4em] text-sm text-emerald-300">AquaDrop</p>
-          <h1 className="mt-3 text-3xl font-semibold sm:text-4xl">Savon moussant durable</h1>
-          <p className="mt-3 max-w-2xl text-base text-emerald-100 sm:text-lg">
-            Découvrez une solution innovante pour garder vos mains propres tout en réduisant votre impact environnemental. AquaDrop offre une mousse généreuse, des parfums raffinés et un design élégant.
-          </p>
+    <div className="min-h-screen bg-aquadrop-bg-deep text-aquadrop-ink-body">
+      <header className="border-b border-white/5 bg-aquadrop-bg-deep/80 backdrop-blur-sm">
+        <div className="container flex items-center justify-between py-6">
+          <a href="#" className="text-sm font-semibold uppercase tracking-[0.4em] text-aquadrop-ink-primary">
+            Aquadrop
+          </a>
+          <nav aria-label="Navigation principale" className="hidden items-center gap-8 text-xs uppercase tracking-[0.28em] text-aquadrop-neutral-100/70 md:flex">
+            <a href="#collection">Collection</a>
+            <a href="#engagements">Engagements</a>
+            <a href="#recharges">Recharges</a>
+          </nav>
+          <a className="btn-secondary hidden sm:inline-flex" href="#compte">
+            Mon espace
+          </a>
         </div>
       </header>
 
-      <main className="mx-auto flex max-w-6xl flex-col gap-16 px-6 pb-16">
-        <section className="overflow-hidden rounded-3xl bg-gradient-to-r from-emerald-900 to-emerald-800">
-          <div className="grid items-center gap-8 p-8 lg:grid-cols-[1.1fr,0.9fr]">
-            <div>
-              <h2 className="text-2xl font-semibold sm:text-3xl">La nouvelle génération de savon moussant</h2>
-              <p className="mt-4 text-base text-emerald-100 sm:text-lg">
-                AquaDrop combine élégance et efficacité. Trois univers parfumés – Sport, Eco et Sans Fragrance – répondent à toutes vos envies. Chaque flacon rechargeable est pensé pour durer et réduire les déchets plastiques.
+      <main>
+        <Hero />
+
+        <section id="collection" className="bg-aquadrop-bg-deep py-24">
+          <div className="container">
+            <div className="flex flex-col gap-6 text-center sm:text-left">
+              <p className="text-xs font-semibold uppercase tracking-[0.42em] text-aquadrop-ink-primary/70">
+                Collection signature
               </p>
-              <div className="mt-6 flex flex-wrap gap-3">
-                <span className="rounded-full bg-emerald-700/60 px-4 py-2 text-sm font-medium uppercase tracking-wide">
-                  Rechargeable
-                </span>
-                <span className="rounded-full bg-emerald-700/60 px-4 py-2 text-sm font-medium uppercase tracking-wide">
-                  Sans plastique inutile
-                </span>
-                <span className="rounded-full bg-emerald-700/60 px-4 py-2 text-sm font-medium uppercase tracking-wide">
-                  Made in France
-                </span>
+              <h2 className="text-balance text-4xl leading-tight sm:text-5xl">Des rituels sensoriels, des économies concrètes</h2>
+              <p className="mx-auto max-w-3xl text-base text-aquadrop-neutral-100/80 sm:mx-0">
+                Chaque coffret associe un flacon mousseur durable à des pastilles concentrées prêtes à l’emploi. Nos accords olfactifs sont pensés pour sublimer votre intérieur tout en réduisant le plastique à usage unique.
+              </p>
+            </div>
+            <div className="mt-16 grid gap-10 lg:grid-cols-3">
+              {products.map((product) => (
+                <ProductCard key={product.name} {...product} />
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section
+          id="engagements"
+          className="bg-aquadrop-surface-1/50 py-20"
+          aria-labelledby="engagements-title"
+        >
+          <div className="container grid gap-12 lg:grid-cols-[0.8fr,1.2fr]">
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-[0.42em] text-aquadrop-ink-primary/70">
+                Engagements durables
+              </p>
+              <h2 id="engagements-title" className="mt-4 text-balance text-4xl leading-tight">
+                Une expérience luxueuse qui protège la planète
+              </h2>
+            </div>
+            <div className="grid gap-8 sm:grid-cols-2">
+              <article className="space-y-3">
+                <h3 className="text-xl leading-tight">Ingrédients sourcés</h3>
+                <p className="text-sm text-aquadrop-neutral-100/80">
+                  Pastilles formulées en France avec des tensioactifs d’origine végétale, sans sulfates agressifs.
+                </p>
+              </article>
+              <article className="space-y-3">
+                <h3 className="text-xl leading-tight">Économie circulaire</h3>
+                <p className="text-sm text-aquadrop-neutral-100/80">
+                  Emballages recyclables, production maîtrisée et logistique optimisée pour réduire l’empreinte carbone.
+                </p>
+              </article>
+              <article className="space-y-3">
+                <h3 className="text-xl leading-tight">Design durable</h3>
+                <p className="text-sm text-aquadrop-neutral-100/80">
+                  Verre renforcé, finitions mates et pièces remplaçables pour prolonger la durée de vie du flacon.
+                </p>
+              </article>
+              <article className="space-y-3">
+                <h3 className="text-xl leading-tight">Expérience sensorielle</h3>
+                <p className="text-sm text-aquadrop-neutral-100/80">
+                  Trois univers olfactifs équilibrés pour accompagner chaque moment de la journée sans saturation.
+                </p>
+              </article>
+            </div>
+          </div>
+        </section>
+
+        <section id="recharges" className="bg-aquadrop-bg-deep py-24">
+          <div className="container grid gap-12 rounded-[24px] border border-white/5 bg-aquadrop-surface-1/70 p-12 lg:grid-cols-[1.1fr,0.9fr]">
+            <div className="space-y-6">
+              <p className="text-xs font-semibold uppercase tracking-[0.42em] text-aquadrop-ink-primary/70">
+                Recharges intelligentes
+              </p>
+              <h2 className="text-balance text-4xl leading-tight">
+                Des pastilles compactes pour 1 mois de mousse soyeuse
+              </h2>
+              <p className="text-base text-aquadrop-neutral-100/80">
+                Glissez une pastille dans votre flacon, ajoutez de l’eau chaude et profitez d’une mousse dense, sans parabènes ni colorants artificiels. Le format compact réduit l’impact carbone du transport.
+              </p>
+              <div className="flex flex-wrap gap-3 text-xs uppercase tracking-[0.28em] text-aquadrop-neutral-100/70">
+                <span className="rounded-full bg-aquadrop-accent-teal/30 px-4 py-2">Sport</span>
+                <span className="rounded-full bg-aquadrop-accent-olive/30 px-4 py-2">Eco</span>
+                <span className="rounded-full bg-aquadrop-accent-sand/40 px-4 py-2 text-aquadrop-bg-deep">Sans fragrance</span>
               </div>
             </div>
-            <figure className="flex justify-center">
-              <ProductIllustration />
-            </figure>
+            <div className="flex flex-col justify-center gap-6 rounded-[20px] border border-white/5 bg-aquadrop-bg-deep/80 p-10 shadow-aquadrop-soft">
+              <p className="text-sm uppercase tracking-[0.32em] text-aquadrop-ink-primary/70">Routine recommandée</p>
+              <ul className="space-y-4 text-sm text-aquadrop-neutral-100/80">
+                <li className="flex gap-3">
+                  <span className="mt-1 h-2 w-2 rounded-full bg-aquadrop-ink-primary" aria-hidden="true" />
+                  Diluer 200&nbsp;ml d’eau tiède avec 1 pastille.
+                </li>
+                <li className="flex gap-3">
+                  <span className="mt-1 h-2 w-2 rounded-full bg-aquadrop-ink-primary" aria-hidden="true" />
+                  Laisser reposer 6 heures pour révéler la mousse.
+                </li>
+                <li className="flex gap-3">
+                  <span className="mt-1 h-2 w-2 rounded-full bg-aquadrop-ink-primary" aria-hidden="true" />
+                  Agiter avant chaque utilisation pour un nuage velouté.
+                </li>
+              </ul>
+              <a className="btn-primary self-start" href="#collection">
+                Choisir ma recharge
+              </a>
+            </div>
           </div>
-        </section>
-
-        <section>
-          <h2 className="text-center text-2xl font-semibold sm:text-3xl">Pourquoi choisir AquaDrop ?</h2>
-          <div className="mt-10 grid gap-6 md:grid-cols-3">
-            {features.map((feature) => (
-              <article
-                key={feature.title}
-                className="rounded-2xl bg-emerald-900/70 p-6 shadow-lg shadow-emerald-950/40 transition-transform hover:-translate-y-1"
-              >
-                <h3 className="text-xl font-semibold text-emerald-100">{feature.title}</h3>
-                <p className="mt-3 text-sm text-emerald-200 sm:text-base">{feature.description}</p>
-              </article>
-            ))}
-          </div>
-        </section>
-
-        <section className="overflow-hidden rounded-3xl border border-emerald-700/40 bg-emerald-900/70 p-8 text-center">
-          <h2 className="text-2xl font-semibold sm:text-3xl">Prêt à transformer votre routine ?</h2>
-          <p className="mt-3 text-base text-emerald-100 sm:text-lg">
-            Rejoignez la communauté AquaDrop et profitez d’un savon moussant haut de gamme, économique et respectueux de la planète.
-          </p>
-          <button className="mt-6 inline-flex items-center justify-center rounded-full bg-emerald-400 px-6 py-3 text-sm font-semibold uppercase tracking-wide text-emerald-950 transition hover:bg-emerald-300">
-            Commander maintenant
-          </button>
         </section>
       </main>
 
-      <footer className="border-t border-emerald-800/60 bg-emerald-950/40 py-8 text-center text-sm text-emerald-200">
-        © {new Date().getFullYear()} AquaDrop. Tous droits réservés.
+      <footer className="border-t border-white/5 bg-aquadrop-bg-deep py-10 text-center text-xs uppercase tracking-[0.32em] text-aquadrop-neutral-700">
+        © {new Date().getFullYear()} Aquadrop · Durable par nature
       </footer>
     </div>
   );
 }
 
 export default App;
-

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,0 +1,81 @@
+const Hero = () => {
+  return (
+    <section className="relative overflow-hidden bg-aquadrop-bg-deep py-24">
+      <div className="container relative z-10 grid gap-16 lg:grid-cols-[1.05fr,0.95fr]">
+        <div className="max-w-xl">
+          <p className="text-xs font-semibold uppercase tracking-[0.42em] text-aquadrop-ink-primary/70">
+            AquaDrop Collection
+          </p>
+          <h1 className="mt-6 text-balance text-5xl leading-[1.05] sm:text-6xl">
+            Rituels durables pour des mains impeccables
+          </h1>
+          <p className="mt-6 text-lg text-aquadrop-neutral-100/90 sm:max-w-lg">
+            Pastilles concentrées et flacon mousseur réutilisable : une expérience premium, écologique et économique qui sublime
+            chaque lavage de mains.
+          </p>
+          <div className="mt-10 flex flex-wrap gap-4">
+            <a className="btn-primary" href="#collection">
+              Découvrir Aquadrop
+            </a>
+            <a className="btn-secondary" href="#recharges">
+              Voir la recharge
+            </a>
+          </div>
+          <dl className="mt-12 grid gap-6 text-sm text-aquadrop-neutral-100/70 sm:grid-cols-3">
+            <div>
+              <dt className="text-xs font-semibold uppercase tracking-[0.36em] text-aquadrop-ink-primary/80">
+                Impact
+              </dt>
+              <dd className="mt-2 text-base text-aquadrop-neutral-100">-92% de plastique</dd>
+            </div>
+            <div>
+              <dt className="text-xs font-semibold uppercase tracking-[0.36em] text-aquadrop-ink-primary/80">
+                Mousse
+              </dt>
+              <dd className="mt-2 text-base text-aquadrop-neutral-100">Dense & soyeuse</dd>
+            </div>
+            <div>
+              <dt className="text-xs font-semibold uppercase tracking-[0.36em] text-aquadrop-ink-primary/80">
+                Durée
+              </dt>
+              <dd className="mt-2 text-base text-aquadrop-neutral-100">30 jours / recharge</dd>
+            </div>
+          </dl>
+        </div>
+        <div className="relative flex justify-center">
+          <div
+            className="relative aspect-[3/4] w-full max-w-md rounded-[24px] border border-white/8 bg-aquadrop-surface-1/80 p-8 shadow-aquadrop-soft"
+            aria-hidden="true"
+          >
+            <div className="absolute inset-0 -z-10 rounded-[24px] border border-aquadrop-ink-primary/10" />
+            <div className="flex h-full flex-col justify-between">
+              <div className="space-y-4">
+                <span className="badge-sand">Starter</span>
+                <h2 className="text-2xl leading-tight text-aquadrop-ink-primary">
+                  Flacon mousseur en verre fumé
+                </h2>
+                <p className="text-sm text-aquadrop-neutral-100/80">
+                  Un design intemporel aux lignes mates, conçu pour durer et valoriser vos recharges.
+                </p>
+              </div>
+              <div className="relative mt-8 flex flex-1 items-end justify-center">
+                <div className="relative h-64 w-36 rounded-[18px] bg-aquadrop-accent-teal/90">
+                  <div className="absolute inset-x-4 top-5 h-20 rounded-[14px] bg-aquadrop-accent-sand/90" />
+                  <div className="absolute inset-x-6 bottom-6 h-28 rounded-[12px] bg-white/15" />
+                </div>
+                <div className="absolute -right-8 bottom-10 h-28 w-28 rounded-full border border-aquadrop-ink-primary/30 bg-aquadrop-accent-olive/40 backdrop-blur-sm" />
+                <div className="absolute -left-6 -top-6 h-24 w-24 rounded-full border border-aquadrop-ink-primary/30 bg-aquadrop-accent-teal/30" />
+              </div>
+              <p className="mt-10 text-xs uppercase tracking-[0.32em] text-aquadrop-neutral-700">
+                Rechargeable · Nettoyage sensoriel
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div className="absolute left-1/2 top-1/2 -z-0 h-[520px] w-[520px] -translate-x-1/2 -translate-y-1/2 rounded-full bg-aquadrop-accent-teal/10 blur-3xl" />
+    </section>
+  );
+};
+
+export default Hero;

--- a/src/components/ProductCard.tsx
+++ b/src/components/ProductCard.tsx
@@ -1,0 +1,71 @@
+type BadgeTone = 'teal' | 'olive' | 'sand';
+
+type ProductCardProps = {
+  name: string;
+  description: string;
+  price: string;
+  badgeLabel: string;
+  badgeTone: BadgeTone;
+  options: string[];
+};
+
+const badgeClassMap: Record<BadgeTone, string> = {
+  teal: 'badge-teal',
+  olive: 'badge-olive',
+  sand: 'badge-sand',
+};
+
+const ProductCard = ({ name, description, price, badgeLabel, badgeTone, options }: ProductCardProps) => {
+  return (
+    <article className="card" aria-labelledby={`${name.replace(/\s+/g, '-')}-title`}>
+      <header className="flex items-start justify-between gap-4">
+        <div className="space-y-2">
+          <span className={badgeClassMap[badgeTone]}>{badgeLabel}</span>
+          <h3 id={`${name.replace(/\s+/g, '-')}-title`} className="text-balance text-3xl leading-[1.1]">
+            {name}
+          </h3>
+        </div>
+        <div className="relative h-20 w-20 overflow-hidden rounded-full border border-aquadrop-ink-primary/20 bg-aquadrop-surface-1">
+          <div className="absolute inset-2 rounded-full border border-white/10 bg-aquadrop-accent-teal/40" />
+          <div className="absolute bottom-3 left-1/2 h-10 w-5 -translate-x-1/2 rounded-full bg-aquadrop-ink-primary/70" />
+        </div>
+      </header>
+      <p className="mt-6 text-sm text-aquadrop-neutral-100/80">{description}</p>
+      <ul className="mt-6 space-y-3 text-sm text-aquadrop-neutral-100/80">
+        <li className="flex items-center gap-3">
+          <span className="inline-flex h-6 w-6 items-center justify-center rounded-full border border-aquadrop-ink-primary/30 text-[10px] font-semibold uppercase tracking-[0.28em] text-aquadrop-ink-primary">
+            ECO
+          </span>
+          Réutilisable, verre épais et pompe inox
+        </li>
+        <li className="flex items-center gap-3">
+          <span className="inline-flex h-6 w-6 items-center justify-center rounded-full border border-aquadrop-ink-primary/30 text-[10px] font-semibold uppercase tracking-[0.28em] text-aquadrop-ink-primary">
+            30j
+          </span>
+          Une pastille = 250&nbsp;ml de mousse généreuse
+        </li>
+      </ul>
+      <div className="mt-8 space-y-4">
+        <label className="text-xs font-semibold uppercase tracking-[0.32em] text-aquadrop-neutral-700" htmlFor={`${name.replace(/\s+/g, '-')}-options`}>
+          Sélectionner la recharge
+        </label>
+        <select id={`${name.replace(/\s+/g, '-')}-options`}>
+          {options.map((option) => (
+            <option key={option}>{option}</option>
+          ))}
+        </select>
+      </div>
+      <div className="mt-8 flex items-center justify-between">
+        <p className="text-lg font-semibold text-aquadrop-ink-primary">{price}</p>
+        <button type="button" className="btn-primary">
+          Ajouter
+        </button>
+      </div>
+      <p className="mt-8 text-xs uppercase tracking-[0.28em] text-aquadrop-neutral-700">
+        Réutilisable · Moins de plastique
+      </p>
+    </article>
+  );
+};
+
+export default ProductCard;

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,138 @@
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Playfair+Display:wght@600;700&display=swap');
+
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer base {
+  :root {
+    color-scheme: dark;
+    background-color: theme('colors.aquadrop.bg-deep');
+    color: theme('colors.aquadrop.ink-body');
+  }
+
+  html {
+    @apply bg-aquadrop-bg-deep text-aquadrop-ink-body;
+  }
+
+  body {
+    @apply min-h-screen bg-aquadrop-bg-deep font-body text-base text-aquadrop-ink-body antialiased;
+  }
+
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6 {
+    @apply font-heading text-aquadrop-ink-primary;
+  }
+
+  h1 {
+    @apply text-4xl uppercase tracking-[0.32em] leading-tight;
+  }
+
+  h2 {
+    @apply text-3xl tracking-[0.16em];
+  }
+
+  h3 {
+    @apply text-2xl tracking-[0.12em];
+  }
+
+  p,
+  li,
+  span,
+  label {
+    @apply text-aquadrop-ink-body;
+  }
+
+  a {
+    @apply font-medium text-aquadrop-ink-primary transition-colors duration-200;
+  }
+
+  a:hover,
+  a:focus-visible {
+    @apply underline decoration-2 decoration-aquadrop-ink-primary/80;
+  }
+
+  button,
+  input,
+  select,
+  textarea {
+    @apply font-body text-sm text-aquadrop-ink-body;
+  }
+
+  input,
+  select,
+  textarea {
+    @apply w-full rounded-[12px] border border-[#25473D] bg-aquadrop-surface-1/80 px-4 py-3 text-sm placeholder:text-aquadrop-neutral-700 focus:outline-none focus:ring-2 focus:ring-aquadrop-ink-primary;
+  }
+
+  ::selection {
+    @apply bg-aquadrop-ink-primary/30 text-aquadrop-neutral-100;
+  }
+
+  :focus-visible {
+    @apply outline-none ring-2 ring-aquadrop-ink-primary ring-offset-2 ring-offset-aquadrop-bg-deep;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+      animation-duration: 0.01ms !important;
+      animation-iteration-count: 1 !important;
+      transition-duration: 0.01ms !important;
+      scroll-behavior: auto !important;
+    }
+  }
+}
+
+@layer components {
+  .btn {
+    @apply inline-flex items-center justify-center gap-2 rounded-full px-6 py-[14px] text-sm font-semibold uppercase tracking-[0.22em] transition-colors duration-200 focus-visible:ring-2 focus-visible:ring-aquadrop-ink-primary focus-visible:ring-offset-2 focus-visible:ring-offset-aquadrop-bg-deep;
+  }
+
+  .btn-primary {
+    @apply btn bg-aquadrop-ink-primary text-aquadrop-bg-deep shadow-none hover:bg-[#cda95d];
+  }
+
+  .btn-secondary {
+    @apply btn border border-aquadrop-ink-primary bg-transparent text-aquadrop-ink-primary hover:bg-aquadrop-surface-1/70;
+  }
+
+  .card {
+    @apply rounded-[16px] border border-white/5 bg-aquadrop-surface-1/80 p-6 shadow-aquadrop-soft backdrop-blur-sm transition-transform duration-300 ease-out hover:-translate-y-1;
+  }
+
+  .badge {
+    @apply inline-flex items-center rounded-full px-4 py-1 text-xs font-semibold uppercase tracking-[0.28em];
+  }
+
+  .badge-teal {
+    @apply badge bg-aquadrop-accent-teal text-aquadrop-neutral-100;
+  }
+
+  .badge-olive {
+    @apply badge bg-aquadrop-accent-olive text-aquadrop-neutral-100;
+  }
+
+  .badge-sand {
+    @apply badge bg-aquadrop-accent-sand text-aquadrop-bg-deep;
+  }
+
+  .form-helper {
+    @apply mt-2 text-xs uppercase tracking-[0.24em] text-aquadrop-neutral-700;
+  }
+}
+
+@layer utilities {
+  .text-shadow-subtle {
+    text-shadow: 0 1px 2px rgba(0, 0, 0, 0.35);
+  }
+
+  .text-balance {
+    text-wrap: balance;
+  }
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,8 +1,50 @@
+import defaultTheme from 'tailwindcss/defaultTheme';
+
 /** @type {import('tailwindcss').Config} */
 export default {
   content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
   theme: {
-    extend: {},
+    container: {
+      center: true,
+      padding: {
+        DEFAULT: '1.5rem',
+        sm: '2rem',
+        lg: '3rem',
+        xl: '3.5rem',
+        '2xl': '4rem',
+      },
+      screens: {
+        sm: '640px',
+        md: '768px',
+        lg: '1024px',
+        xl: '1280px',
+        '2xl': '1440px',
+      },
+    },
+    extend: {
+      colors: {
+        aquadrop: {
+          'bg-deep': '#0F2F27',
+          'surface-1': '#173C32',
+          'ink-primary': '#E0C06A',
+          'ink-body': '#E8E3D6',
+          'accent-teal': '#2D6F65',
+          'accent-olive': '#547A3A',
+          'accent-sand': '#DCCDAE',
+          'neutral-100': '#F3EEE3',
+          'neutral-700': '#5A5A54',
+          success: '#7FB069',
+          error: '#D96C5F',
+        },
+      },
+      fontFamily: {
+        heading: ['"Playfair Display"', ...defaultTheme.fontFamily.serif],
+        body: ['Inter', ...defaultTheme.fontFamily.sans],
+      },
+      boxShadow: {
+        'aquadrop-soft': '0 32px 80px -40px rgba(0, 0, 0, 0.7)',
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
## Summary
- add Aquadrop theme tokens, fonts, and container settings in Tailwind to support the new palette
- establish global typography, button, badge, and form styles that match the premium forest aesthetic
- rebuild the homepage hero and collection sections with the new Hero and ProductCard components

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68dad32d05b88332a7fe34c679b2c495