### PR TITLE
Fix GitHub Pages artifact path

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: dist
+          path: ./dist
 
   deploy:
     needs: build


### PR DESCRIPTION
## Summary
- configure the Pages deployment workflow to upload the built dist directory

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dad9ad4d208332982740548bbfa068